### PR TITLE
Allowed to use AlertKit on WatchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "AlertKit",
     platforms: [
-        .iOS(.v14)
+        .iOS(.v14),
+        .watchOS(.v7)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/AlertKit/CustomAlertViewModifier.swift
+++ b/Sources/AlertKit/CustomAlertViewModifier.swift
@@ -127,3 +127,10 @@ public struct CustomAlertViewModifier<AlertContent: View>: ViewModifier {
     
 }
 
+#if os(watchOS)
+extension UIColor {
+    public static var systemBackground: UIColor {
+        return UIColor(.black)
+    }
+}
+#endif


### PR DESCRIPTION
1. Enabled WatchOs 7+ support
2. Fixed `UIColor` capability issue