### PR TITLE
Make disabling buttons possible

### DIFF
--- a/Sources/AlertKit/CustomAlertButton.swift
+++ b/Sources/AlertKit/CustomAlertButton.swift
@@ -28,8 +28,8 @@ public struct CustomAlertButton {
     }
 
     public static func regular<Content: View>(@ViewBuilder content: @escaping () -> Content,
-        action: @escaping () -> Void) -> CustomAlertButton {
-        CustomAlertButton(content: content, action: action, type: .regular)
+        action: @escaping () -> Void, isDisabled: Bool = false) -> CustomAlertButton {
+        CustomAlertButton(content: content, action: action, type: .regular, isDisabled: isDisabled)
     }
 
     public init<Content: View>(@ViewBuilder content: @escaping () -> Content, action: @escaping () -> Void, type: Variant, isDisabled: Bool = false) {

--- a/Sources/AlertKit/CustomAlertButton.swift
+++ b/Sources/AlertKit/CustomAlertButton.swift
@@ -17,6 +17,7 @@ public struct CustomAlertButton {
     public let content: AnyView
     public let action: () -> Void
     public let type: Variant
+    public let isDisabled: Bool
 
     public var isCancel: Bool {
         type == .cancel
@@ -31,9 +32,10 @@ public struct CustomAlertButton {
         CustomAlertButton(content: content, action: action, type: .regular)
     }
 
-    public init<Content: View>(@ViewBuilder content: @escaping () -> Content, action: @escaping () -> Void, type: Variant ) {
+    public init<Content: View>(@ViewBuilder content: @escaping () -> Content, action: @escaping () -> Void, type: Variant, isDisabled: Bool = false) {
         self.content = AnyView(content())
         self.type = type
         self.action = action
+        self.isDisabled = isDisabled
     }
 }

--- a/Sources/AlertKit/CustomAlertViewModifier.swift
+++ b/Sources/AlertKit/CustomAlertViewModifier.swift
@@ -23,7 +23,10 @@ public struct CustomAlertViewModifier<AlertContent: View>: ViewModifier {
             content.disabled(customAlertManager.isPresented)
             if customAlertManager.isPresented {
                 GeometryReader { geometry in
-                    Color.black.opacity(0.2).ignoresSafeArea()
+                    Color(.systemBackground)
+                        .colorInvert()
+                        .opacity(0.2)
+                        .ignoresSafeArea()
                     HStack {
                         Spacer()
                         VStack {

--- a/Sources/AlertKit/CustomAlertViewModifier.swift
+++ b/Sources/AlertKit/CustomAlertViewModifier.swift
@@ -82,6 +82,7 @@ public struct CustomAlertViewModifier<AlertContent: View>: ViewModifier {
                 }, label: {
                     current.content
                 })
+                .disabled(current.isDisabled)
                 .padding(8)
                 .frame(minHeight: 44)
             }

--- a/Sources/AlertKit/CustomAlertViewModifier.swift
+++ b/Sources/AlertKit/CustomAlertViewModifier.swift
@@ -117,6 +117,7 @@ public struct CustomAlertViewModifier<AlertContent: View>: ViewModifier {
                     }, label: {
                         current.content
                     })
+                    .disabled(current.isDisabled)
                     .padding(8)
                     .frame(maxWidth: maxHorizontalWidth, minHeight: 44)
                 }


### PR DESCRIPTION
It should be possible to disable buttons. An example use case would be input verification. The user should not be able to trigger certain buttons if the input is invalid.